### PR TITLE
Bump MochiWeb version to 2.9.0p2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, "2.9.0", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p1"}}}
+ [{mochiweb, "2.9.0", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
  ]}.
 
 {dev_only_deps,


### PR DESCRIPTION
This gets us the spurious 400 error fix that we've patched into MochiWeb.
