### PR TITLE
Bump MochiWeb version to 2.9.0p2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, "2.9.0", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p1"}}}
+ [{mochiweb, "2.9.0.*", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
  ]}.
 
 {dev_only_deps,


### PR DESCRIPTION
This pulls in the fix for the spurious 400 errors.

Once this is merged, we'll tag a custom Basho release as 1.10.8-basho1. This will include some additional stuff over 1.10.8 besides just this fix, since we're merging into the latest develop...but all the new stuff seems to be pretty innocuous, so this saves us from having to create an extra additional branch off of some past point in history.
