### PR TITLE
change otp version check to accommodate patched R15B01 releases

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 OtpVersion = erlang:system_info(otp_release),
-Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion =< "R15B01" of
+Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion < "R15B02" of
               true  ->
                   HashDefine = [{d,old_hash}],
                   case lists:keysearch(erl_opts, 1, CONFIG) of


### PR DESCRIPTION
If the string returned by erlang:system_info(otp_release) begins with R15B01 but has any suffix the previous version check would erroneously assume that it supported APIs introduced in R15B02.

This is pretty obscure and unlikely to be relevant to most anyone any more, but it can bite painfully in certain regression testing scenarios.
