### PR TITLE
Develop 2.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, ".*", {git, "git://github.com/basho/mochiweb.git", {branch, "develop-2.9"}}}
+ [{mochiweb, ".*", {git, "git://github.com/martinsumner/mochiweb.git", {branch, "develop-2.9"}}}
  ]}.
 
 {dev_only_deps,

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, "2.9.0.*", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
+ [{mochiweb, ".*", {git, "git://github.com/basho/mochiweb.git", {branch, "develop-2.9"}}}
  ]}.
 
 {dev_only_deps,

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, ".*", {git, "git://github.com/martinsumner/mochiweb.git", {branch, "develop-2.9"}}}
+ [{mochiweb, ".*", {git, "git://github.com/basho/mochiweb.git", {branch, "develop-2.9"}}}
  ]}.
 
 {dev_only_deps,

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -30,7 +30,14 @@
 -define (WM_OPTION_DEFAULTS, [{error_handler, webmachine_error_handler}]).
 
 start(Options) ->
-    {DispatchList, PName, DGroup, WMOptions, OtherOptions} = get_wm_options(Options),
+    {DispatchList, PName, DGroup, WMOptions, OtherOptions0} = get_wm_options(Options),
+    OtherOptions =
+        case application:get_env(webmachine, recbuf) of
+            {ok, RecBuf} ->
+                [{recbuf, RecBuf}|OtherOptions0];
+            _ ->
+                OtherOptions0
+        end,
     webmachine_router:init_routes(DGroup, DispatchList),
     _ = [application_set_unless_env_or_undef(K, V) || {K, V} <- WMOptions],
     MochiName = list_to_atom(to_list(PName) ++ "_mochiweb"),


### PR DESCRIPTION
Allows the recbuf to be set in advanced.config, and then passed through to mochiweb.  This allows for Riak customer who hit the default 8KB limit on HTTP header sizes to override this by changing the buffer size.