### PR TITLE
Update rebar.config

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,0 +1,11 @@
+minimum_reviewers: 2
+merge: true
+build_steps:
+  - make clean
+  - make deps
+  - make compile
+  - make test
+  - make xref
+  - make dialyzer
+org_mode: true
+timeout: 1800

--- a/rebar.config
+++ b/rebar.config
@@ -6,10 +6,10 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, "2.9.0.*", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
+ [{mochiweb, "2.9.0.*", {git, "https://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
  ]}.
 
 {dev_only_deps,
- [{meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-  {ibrowse, "4.*", {git, "git://github.com/basho/ibrowse.git", {tag, "v4.3"}}}
+ [{meck, "0.8.*", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
+  {ibrowse, "4.*", {git, "https://github.com/basho/ibrowse.git", {tag, "v4.3"}}}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {xref_checks, [undefined_function_calls]}.
 
 {deps,
- [{mochiweb, "2.9.0", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p1"}}}
+ [{mochiweb, "2.9.0.*", {git, "git://github.com/basho/mochiweb.git", {tag, "v2.9.0p2"}}}
  ]}.
 
 {dev_only_deps,

--- a/rebar.config
+++ b/rebar.config
@@ -11,5 +11,5 @@
 
 {dev_only_deps,
  [{meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-  {ibrowse, "4.0.2", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
+  {ibrowse, "4.*", {git, "git://github.com/basho/ibrowse.git", {tag, "v4.3"}}}
  ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 OtpVersion = erlang:system_info(otp_release),
-Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion =< "R15B01" of
+Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion < "R15B02" of
               true  ->
                   HashDefine = [{d,old_hash}],
                   case lists:keysearch(erl_opts, 1, CONFIG) of


### PR DESCRIPTION
We are facing cloning issue, currently the builds are getting  failed while getting deps from webmachine (it is an open source repository) with below error:
Cloning into 'mochiweb'...
Build timed out (after 10 minutes). Marking the build as failed.
Build was aborted
ERROR: git clone -n git://github.com/basho/mochiweb.git mochiweb failed with error: 143 and output:
Cloning into 'mochiweb'...
 o fix above issue, it seems we need to change gerrit mirror  from "git:" to "https:"

Please do the needful as soon as possible eg {git,"https://github.com/basho/mochiweb.git",
                           {tag,"1.5.1p7"}}